### PR TITLE
Merge dispatch:mocha-core into practicalmeteor:mocha-core

### DIFF
--- a/.npm/package/.gitignore
+++ b/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.npm/package/README
+++ b/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,111 @@
+{
+  "dependencies": {
+    "mocha": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.4.5.tgz",
+      "from": "mocha@2.4.5",
+      "dependencies": {
+        "commander": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+          "from": "commander@2.3.0"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "from": "debug@2.2.0",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "from": "ms@0.7.1"
+            }
+          }
+        },
+        "diff": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+          "from": "diff@1.4.0"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+          "from": "escape-string-regexp@1.0.2"
+        },
+        "glob": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+          "from": "glob@3.2.3",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+              "from": "graceful-fs@>=2.0.0 <2.1.0"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "from": "inherits@>=2.0.0 <3.0.0"
+            },
+            "minimatch": {
+              "version": "0.2.14",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "from": "minimatch@>=0.2.11 <0.3.0",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.7.3",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                  "from": "lru-cache@>=2.0.0 <3.0.0"
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "from": "sigmund@>=1.0.0 <1.1.0"
+                }
+              }
+            }
+          }
+        },
+        "growl": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+          "from": "growl@1.8.1"
+        },
+        "jade": {
+          "version": "0.26.3",
+          "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+          "from": "jade@0.26.3",
+          "dependencies": {
+            "commander": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+              "from": "commander@0.6.1"
+            },
+            "mkdirp": {
+              "version": "0.3.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+              "from": "mkdirp@0.3.0"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "from": "mkdirp@0.5.1",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "from": "minimist@0.0.8"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+          "from": "supports-color@1.2.0"
+        }
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # practicalmeteor:mocha-core
 
-This is an internal package. Please use [practicalmeteor:mocha](https://atmospherejs.com/practicalmeteor/mocha).
+This is an internal package. Please use one of the following test driver packages:
 
-This is a fork of [mike:mocha-core](https://atmospherejs.com/mike/mocha-core) with the following changes:
+## Meteor pre-1.3
 
-1. Removed the mocha npm dependency so we can use any mocha version with the server side fibers aware code that mike has created.
+* [practicalmeteor:mocha](https://atmospherejs.com/practicalmeteor/mocha) Runs client and server code tests and displays all results in a browser. Use [spacejam](https://www.npmjs.com/package/spacejam) for command line / CI support.
 
-2. It includes the source code of server side tests, so it can be displayed in reporters. We will create a PR for this with mike.
+## Meteor 1.3+
 
-This package is used in [practicalmeteor:mocha](https://atmospherejs.com/practicalmeteor/mocha), which was created in order to be able to run mocha tests:
+Choose the one that makes sense for your app. You may depend on more than one.
 
-1. From the command line using [spacejam](https://www.npmjs.com/package/spacejam)
-
-2. In the browser, with no dependency on either mongodb nor velocity.
+* [practicalmeteor:mocha](https://atmospherejs.com/practicalmeteor/mocha) Runs client and server package or app tests and displays all results in a browser. Use [spacejam](https://www.npmjs.com/package/spacejam) for command line / CI support.
+* [dispatch:mocha-phantomjs](https://atmospherejs.com/dispatch/mocha-phantomjs) Runs client and server package or app tests using PhantomJS and reports all results in the server console. Can be used for running tests on a CI server. Has a watch mode.
+* [dispatch:mocha-browser](https://atmospherejs.com/dispatch/mocha-browser) Runs client and server package or app tests with Mocha reporting client results in a web browser and server results in the server console. Has a watch mode.
+* [dispatch:mocha](https://atmospherejs.com/dispatch/mocha) Runs server-only package or app tests with Mocha and reports all results in the server console. Can be used for running tests on a CI server. Has a watch mode.

--- a/client.js
+++ b/client.js
@@ -1,0 +1,9 @@
+// We need to import the "mocha.js" file specifically because that is the browser entry point.
+import 'mocha/mocha.js';
+
+// This defines "describe", "it", etc.
+mocha.setup({
+  ui: 'bdd',
+});
+
+export { mocha };

--- a/package.js
+++ b/package.js
@@ -1,14 +1,22 @@
 Package.describe({
   name: 'practicalmeteor:mocha-core',
-  summary: "Fibers aware mocha server side wrappers. Internal package - use practicalmeteor:mocha.",
-  version: "0.1.4",
-  debugOnly: true,
-  git: "https://github.com/practicalmeteor/meteor-mocha-core.git"
+  summary: 'Fibers aware mocha server side wrappers. Internal package - use practicalmeteor:mocha.',
+  version: '1.0.0',
+  testOnly: true,
+  git: 'https://github.com/practicalmeteor/meteor-mocha-core.git'
 });
 
+Npm.depends({
+  mocha: '2.4.5',
+});
 
-Package.on_use(function (api, where) {
-  api.use(['underscore@1.0.3'], ['client', 'server']);
-  api.add_files(['server.js'], 'server');
-  api.export("setupGlobals", 'server');
+Package.onUse(function (api, where) {
+  api.versionsFrom('1.3');
+
+  api.use('ecmascript');
+
+  api.mainModule('client.js', 'client');
+  api.mainModule('server.js', 'server');
+
+  api.export(['mochaInstance', 'setupGlobals'], 'server');
 });


### PR DESCRIPTION
This PR adds everything from `dispatch:mocha-core` into this package. If this is merged and all dependent test driver packages are updated to depend on the newer core and use the exported `mochaInstance`, then all the test driver packages can be installed alongside each other without conflict.

The main differences:
- "mocha" NPM package is actually included now
- On the server, `mochaInstance` is exported and you have to use this instance if you want to play nicely with other test driver packages.
- Mocha is automatically initialized in client code, too, so test drivers can just call `setReporter` and `run`
- Updated to ES2015 and Meteor 1.3+
- Since this is not backwards compatible, I bumped to 1.0.0 package version
- Updated readme to explain various test driver pkgs
