### PR TITLE
Allow specifying global mocha timeout

### DIFF
--- a/client.js
+++ b/client.js
@@ -4,6 +4,7 @@ import 'mocha/mocha.js';
 // This defines "describe", "it", etc.
 mocha.setup({
   ui: 'bdd',
+  timeout: Meteor.settings.public["MOCHA_TIMEOUT"] || 2000,
 });
 
 export { mocha };

--- a/server.js
+++ b/server.js
@@ -108,8 +108,12 @@ function setupGlobals(mocha) {
 // can use to ensure they work well with other test driver packages.
 const mochaInstance = new Mocha({
   ui: 'bdd',
-  ignoreLeaks: true
+  ignoreLeaks: true,
+  timeout: process.env.MOCHA_TIMEOUT || 2000
 });
 setupGlobals(mochaInstance);
- 
+
+// Pass timeout to client
+Meteor.settings.public["MOCHA_TIMEOUT"] = process.env.MOCHA_TIMEOUT || 2000;
+
 export { mochaInstance, setupGlobals, Mocha };


### PR DESCRIPTION
Our build server is sometimes a bit slower, and executing a single test can take longer than 2000ms. Sometimes, even a `beforeEach` is marked as failed because it takes longer than 2000ms.

This PR allows to set the global mocha timeout by setting an environment variable, which will override the default value.
